### PR TITLE
Updated confirm email error message

### DIFF
--- a/frontend/src/components/ConfirmEmail.js
+++ b/frontend/src/components/ConfirmEmail.js
@@ -21,7 +21,8 @@ class ConfirmEmail extends Component {
         if (!data.success) {
           this.setState({
             confirmed: false,
-            message: "It looks like you've already confirmed your code",
+            message:
+              "Sorry! It looks like you have already confirmed your email or the confirmation link you just used was old. Please check your inbox for a more recent confirmation email",
             color: "info"
           });
         } else {


### PR DESCRIPTION
changed the confirmation email message so its a little clearer in case the user clicks on an old confirm email or their email is already in the system registered. 

resolves #121 