### PR TITLE
Allow Frontend to Persist when API is down

### DIFF
--- a/api/package-lock.json
+++ b/api/package-lock.json
@@ -116,14 +116,12 @@
     "ansi-regex": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-3.0.0.tgz",
-      "integrity": "sha1-7QMXwyIGT3lGbAKWa922Bas32Zg=",
-      "dev": true
+      "integrity": "sha1-7QMXwyIGT3lGbAKWa922Bas32Zg="
     },
     "ansi-styles": {
       "version": "3.2.1",
       "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.1.tgz",
       "integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
-      "dev": true,
       "requires": {
         "color-convert": "^1.9.0"
       }
@@ -450,6 +448,11 @@
       "resolved": "https://registry.npmjs.org/buffer-equal-constant-time/-/buffer-equal-constant-time-1.0.1.tgz",
       "integrity": "sha1-+OcRMvf/5uAaXJaXpMbz5I1cyBk="
     },
+    "builtin-modules": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/builtin-modules/-/builtin-modules-1.1.1.tgz",
+      "integrity": "sha1-Jw8HbFpywC9bZaR9+Uxf46J4iS8="
+    },
     "bytes": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/bytes/-/bytes-3.0.0.tgz",
@@ -497,7 +500,6 @@
       "version": "2.4.1",
       "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.1.tgz",
       "integrity": "sha512-ObN6h1v2fTJSmUXoS3nMQ92LbDK9be4TV+6G+omQlGJFdcUX5heKi1LZ1YnRMIgwTLEj3E24bT6tYni50rlCfQ==",
-      "dev": true,
       "requires": {
         "ansi-styles": "^3.2.1",
         "escape-string-regexp": "^1.0.5",
@@ -586,6 +588,21 @@
         "tiny-emitter": "^2.0.0"
       }
     },
+    "cliui": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/cliui/-/cliui-4.1.0.tgz",
+      "integrity": "sha512-4FG+RSG9DL7uEwRUZXZn3SS34DiDPfzP0VOiEwtUWlE+AR2EIg+hSyvrIgUUfhdgR/UkAeW2QHgeP+hWrXs7jQ==",
+      "requires": {
+        "string-width": "^2.1.1",
+        "strip-ansi": "^4.0.0",
+        "wrap-ansi": "^2.0.0"
+      }
+    },
+    "code-point-at": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/code-point-at/-/code-point-at-1.1.0.tgz",
+      "integrity": "sha1-DQcLTQQ6W+ozovGkDi7bPZpMz3c="
+    },
     "collection-visit": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/collection-visit/-/collection-visit-1.0.0.tgz",
@@ -599,7 +616,6 @@
       "version": "1.9.3",
       "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-1.9.3.tgz",
       "integrity": "sha512-QfAUtd+vFdAtFQcC8CCyYt1fYWxSqAiK2cSD6zDB8N3cpsEBAvRxp9zOGg6G/SHHJYAT88/az/IuDGALsNVbGg==",
-      "dev": true,
       "requires": {
         "color-name": "1.1.3"
       }
@@ -607,8 +623,7 @@
     "color-name": {
       "version": "1.1.3",
       "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.3.tgz",
-      "integrity": "sha1-p9BVi9icQveV3UIyj3QIMcpTvCU=",
-      "dev": true
+      "integrity": "sha1-p9BVi9icQveV3UIyj3QIMcpTvCU="
     },
     "combined-stream": {
       "version": "1.0.7",
@@ -632,6 +647,37 @@
       "version": "0.0.1",
       "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
       "integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s="
+    },
+    "concurrently": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/concurrently/-/concurrently-4.1.0.tgz",
+      "integrity": "sha512-pwzXCE7qtOB346LyO9eFWpkFJVO3JQZ/qU/feGeaAHiX1M3Rw3zgXKc5cZ8vSH5DGygkjzLFDzA/pwoQDkRNGg==",
+      "requires": {
+        "chalk": "^2.4.1",
+        "date-fns": "^1.23.0",
+        "lodash": "^4.17.10",
+        "read-pkg": "^4.0.1",
+        "rxjs": "^6.3.3",
+        "spawn-command": "^0.0.2-1",
+        "supports-color": "^4.5.0",
+        "tree-kill": "^1.1.0",
+        "yargs": "^12.0.1"
+      },
+      "dependencies": {
+        "has-flag": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-2.0.0.tgz",
+          "integrity": "sha1-6CB68cx7MNRGzHC3NLXovhj4jVE="
+        },
+        "supports-color": {
+          "version": "4.5.0",
+          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-4.5.0.tgz",
+          "integrity": "sha1-vnoN5ITexcXN34s9WRJQRJEvY1s=",
+          "requires": {
+            "has-flag": "^2.0.0"
+          }
+        }
+      }
     },
     "configstore": {
       "version": "3.1.2",
@@ -768,6 +814,11 @@
       "resolved": "https://registry.npmjs.org/date-and-time/-/date-and-time-0.6.3.tgz",
       "integrity": "sha512-lcWy3AXDRJOD7MplwZMmNSRM//kZtJaLz4n6D1P5z9wEmZGBKhJRBIr1Xs9KNQJmdXPblvgffynYji4iylUTcA=="
     },
+    "date-fns": {
+      "version": "1.30.1",
+      "resolved": "https://registry.npmjs.org/date-fns/-/date-fns-1.30.1.tgz",
+      "integrity": "sha512-hBSVCvSmWC+QypYObzwGOd9wqdDpOt+0wl0KbU+R+uuZBS1jN8VsD1ss3irQDknRj5NvxiTF6oj/nDRnN/UQNw=="
+    },
     "debug": {
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/debug/-/debug-3.1.0.tgz",
@@ -775,6 +826,11 @@
       "requires": {
         "ms": "2.0.0"
       }
+    },
+    "decamelize": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/decamelize/-/decamelize-1.2.0.tgz",
+      "integrity": "sha1-9lNNFRSCabIDUue+4m9QH5oZEpA="
     },
     "decko": {
       "version": "1.2.0",
@@ -968,10 +1024,26 @@
       "resolved": "https://registry.npmjs.org/encodeurl/-/encodeurl-1.0.2.tgz",
       "integrity": "sha1-rT/0yG7C0CkyL1oCw6mmBslbP1k="
     },
+    "end-of-stream": {
+      "version": "1.4.1",
+      "resolved": "https://registry.npmjs.org/end-of-stream/-/end-of-stream-1.4.1.tgz",
+      "integrity": "sha512-1MkrZNvWTKCaigbn+W15elq2BB/L22nqrSY5DKlo3X6+vclJm8Bb5djXJBmEX6fS3+zCh/F4VBK5Z2KxJt4s2Q==",
+      "requires": {
+        "once": "^1.4.0"
+      }
+    },
     "entities": {
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/entities/-/entities-1.1.2.tgz",
       "integrity": "sha512-f2LZMYl1Fzu7YSBKg+RoROelpOaNrcGmE9AZubeDfrCEia483oW4MI4VyFd5VNHIgQ/7qm1I0wUHK1eJnn2y2w=="
+    },
+    "error-ex": {
+      "version": "1.3.2",
+      "resolved": "https://registry.npmjs.org/error-ex/-/error-ex-1.3.2.tgz",
+      "integrity": "sha512-7dFHNmqeFSEt2ZBsCriorKnn3Z2pj+fd9kmI6QoWw4//DL+icEBfc0U7qJCisqrTsKTjw4fNFy2pW9OqStD84g==",
+      "requires": {
+        "is-arrayish": "^0.2.1"
+      }
     },
     "es6-promise": {
       "version": "4.2.5",
@@ -986,8 +1058,7 @@
     "escape-string-regexp": {
       "version": "1.0.5",
       "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
-      "integrity": "sha1-G2HAViGQqN/2rjuyzwIAyhMLhtQ=",
-      "dev": true
+      "integrity": "sha1-G2HAViGQqN/2rjuyzwIAyhMLhtQ="
     },
     "esprima": {
       "version": "4.0.1",
@@ -1272,6 +1343,14 @@
           "resolved": "https://registry.npmjs.org/statuses/-/statuses-1.4.0.tgz",
           "integrity": "sha512-zhSCtt8v2NDrRlPQpCNtw/heZLtfUDqxBM1udqikb/Hbk52LK4nQSwr10u77iopCW5LsyHpuXS0GnEc48mLeew=="
         }
+      }
+    },
+    "find-up": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/find-up/-/find-up-3.0.0.tgz",
+      "integrity": "sha512-1yD6RmLI1XBfxugvORwlck6f75tYL+iR0jqwsOrOxMZyGYqUuDhJ0l4AXdO1iX/FTs9cBAMEk1gWSEx1kSbylg==",
+      "requires": {
+        "locate-path": "^3.0.0"
       }
     },
     "follow-redirects": {
@@ -1863,6 +1942,11 @@
         }
       }
     },
+    "get-caller-file": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/get-caller-file/-/get-caller-file-1.0.3.tgz",
+      "integrity": "sha512-3t6rVToeoZfYSGd8YoLFR2DJkiQrIiUrGcjvFX2mDw3bn6k2OtwHN0TNCLbBO+w8qTvimhDkv+LSscbJY1vE6w=="
+    },
     "get-stream": {
       "version": "3.0.0",
       "resolved": "http://registry.npmjs.org/get-stream/-/get-stream-3.0.0.tgz",
@@ -1987,8 +2071,7 @@
     "has-flag": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-3.0.0.tgz",
-      "integrity": "sha1-tdRU3CGZriJWmfNGfloH87lVuv0=",
-      "dev": true
+      "integrity": "sha1-tdRU3CGZriJWmfNGfloH87lVuv0="
     },
     "has-value": {
       "version": "1.0.0",
@@ -2026,6 +2109,11 @@
       "requires": {
         "react-is": "^16.7.0"
       }
+    },
+    "hosted-git-info": {
+      "version": "2.7.1",
+      "resolved": "https://registry.npmjs.org/hosted-git-info/-/hosted-git-info-2.7.1.tgz",
+      "integrity": "sha512-7T/BxH19zbcCTa8XkMlbK5lTo1WtgkFi3GvdWEyNuc4Vex7/9Dqbnpsf4JMydcfj9HCg4zUWFTL3Za6lapg5/w=="
     },
     "htmlparser2": {
       "version": "3.10.0",
@@ -2112,6 +2200,11 @@
       "integrity": "sha512-RZY5huIKCMRWDUqZlEi72f/lmXKMvuszcMBduliQ3nnWbx9X/ZBQO7DijMEYS9EhHBb2qacRUMtC7svLwe0lcw==",
       "dev": true
     },
+    "invert-kv": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/invert-kv/-/invert-kv-2.0.0.tgz",
+      "integrity": "sha512-wPVv/y/QQ/Uiirj/vh3oP+1Ww+AWehmi1g5fFWGPF6IpCBCDVrhgHRMvrLfdYcwDh3QJbGXDW4JAuzxElLSqKA=="
+    },
     "ipaddr.js": {
       "version": "1.8.0",
       "resolved": "https://registry.npmjs.org/ipaddr.js/-/ipaddr.js-1.8.0.tgz",
@@ -2135,6 +2228,11 @@
         }
       }
     },
+    "is-arrayish": {
+      "version": "0.2.1",
+      "resolved": "https://registry.npmjs.org/is-arrayish/-/is-arrayish-0.2.1.tgz",
+      "integrity": "sha1-d8mYQFJ6qOyxqLppe4BkWnqSap0="
+    },
     "is-binary-path": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/is-binary-path/-/is-binary-path-1.0.1.tgz",
@@ -2147,6 +2245,14 @@
       "version": "1.1.6",
       "resolved": "https://registry.npmjs.org/is-buffer/-/is-buffer-1.1.6.tgz",
       "integrity": "sha512-NcdALwpXkTm5Zvvbk7owOUSvVvBKDgKP5/ewfXEznmQFfs4ZRmanOeKBTjRVjka3QFoN6XJ+9F3USqfHqTaU5w=="
+    },
+    "is-builtin-module": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/is-builtin-module/-/is-builtin-module-1.0.0.tgz",
+      "integrity": "sha1-VAVy0096wxGfj3bDDLwbHgN6/74=",
+      "requires": {
+        "builtin-modules": "^1.0.0"
+      }
     },
     "is-ci": {
       "version": "1.2.1",
@@ -2205,8 +2311,7 @@
     "is-fullwidth-code-point": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-2.0.0.tgz",
-      "integrity": "sha1-o7MKXE8ZkYMWeqq5O+764937ZU8=",
-      "dev": true
+      "integrity": "sha1-o7MKXE8ZkYMWeqq5O+764937ZU8="
     },
     "is-glob": {
       "version": "4.0.0",
@@ -2288,8 +2393,7 @@
     "is-stream": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/is-stream/-/is-stream-1.1.0.tgz",
-      "integrity": "sha1-EtSj3U5o4Lec6428hBc66A2RykQ=",
-      "dev": true
+      "integrity": "sha1-EtSj3U5o4Lec6428hBc66A2RykQ="
     },
     "is-typedarray": {
       "version": "1.0.0",
@@ -2309,8 +2413,7 @@
     "isexe": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
-      "integrity": "sha1-6PvzdNxVb/iUehDcsFctYz8s+hA=",
-      "dev": true
+      "integrity": "sha1-6PvzdNxVb/iUehDcsFctYz8s+hA="
     },
     "isobject": {
       "version": "3.0.1",
@@ -2345,6 +2448,11 @@
       "version": "0.1.1",
       "resolved": "https://registry.npmjs.org/jsbn/-/jsbn-0.1.1.tgz",
       "integrity": "sha1-peZUwuWi3rXyAdls77yoDA7y9RM="
+    },
+    "json-parse-better-errors": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/json-parse-better-errors/-/json-parse-better-errors-1.0.2.tgz",
+      "integrity": "sha512-mrqyZKfX5EhL7hvqcV6WG1yYjnjeuYDzDhhcAAUrq8Po85NBQBJP+ZDUT75qZQ98IkUoBqdkExkukOU7Ts2wrw=="
     },
     "json-pointer": {
       "version": "0.6.0",
@@ -2481,6 +2589,14 @@
         "package-json": "^4.0.0"
       }
     },
+    "lcid": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/lcid/-/lcid-2.0.0.tgz",
+      "integrity": "sha512-avPEb8P8EGnwXKClwsNUgryVjllcRqtMYa49NTsbQagYuT1DcXnl1915oxWjoyGrXR6zH/Y0Zc96xWsPcoDKeA==",
+      "requires": {
+        "invert-kv": "^2.0.0"
+      }
+    },
     "loader-utils": {
       "version": "1.2.3",
       "resolved": "https://registry.npmjs.org/loader-utils/-/loader-utils-1.2.3.tgz",
@@ -2489,6 +2605,15 @@
         "big.js": "^5.2.2",
         "emojis-list": "^2.0.0",
         "json5": "^1.0.1"
+      }
+    },
+    "locate-path": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-3.0.0.tgz",
+      "integrity": "sha512-7AO748wWnIhNqAuaty2ZWHkQHRSNfPVIsPIfwEOWO22AmaoVrWavlOcMR5nzTLNYvp36X220/maaRsrec1G65A==",
+      "requires": {
+        "p-locate": "^3.0.0",
+        "path-exists": "^3.0.0"
       }
     },
     "lodash": {
@@ -2594,6 +2719,14 @@
         "pify": "^3.0.0"
       }
     },
+    "map-age-cleaner": {
+      "version": "0.1.3",
+      "resolved": "https://registry.npmjs.org/map-age-cleaner/-/map-age-cleaner-0.1.3.tgz",
+      "integrity": "sha512-bJzx6nMoP6PDLPBFmg7+xRKeFZvFboMrGlxmNj9ClvX53KrmvM5bXFXEWjbz4cz1AFn+jWJ9z/DJSz7hrs0w3w==",
+      "requires": {
+        "p-defer": "^1.0.0"
+      }
+    },
     "map-cache": {
       "version": "0.2.2",
       "resolved": "https://registry.npmjs.org/map-cache/-/map-cache-0.2.2.tgz",
@@ -2621,6 +2754,16 @@
       "version": "0.3.0",
       "resolved": "http://registry.npmjs.org/media-typer/-/media-typer-0.3.0.tgz",
       "integrity": "sha1-hxDXrwqmJvj/+hzgAWhUUmMlV0g="
+    },
+    "mem": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/mem/-/mem-4.1.0.tgz",
+      "integrity": "sha512-I5u6Q1x7wxO0kdOpYBB28xueHADYps5uty/zg936CiG8NTe5sJL8EjrCuLneuDW3PlMdZBGDIn8BirEVdovZvg==",
+      "requires": {
+        "map-age-cleaner": "^0.1.1",
+        "mimic-fn": "^1.0.0",
+        "p-is-promise": "^2.0.0"
+      }
     },
     "memoize-one": {
       "version": "4.0.3",
@@ -2680,6 +2823,11 @@
       "requires": {
         "mime-db": "~1.37.0"
       }
+    },
+    "mimic-fn": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/mimic-fn/-/mimic-fn-1.2.0.tgz",
+      "integrity": "sha512-jf84uxzwiuiIVKiOLpfYk7N46TSy8ubTonmneY9vrpHNAnp0QBt2BxWV9dO3/j+BoVAb+a5G6YDPW3M5HOdMWQ=="
     },
     "min-document": {
       "version": "2.19.0",
@@ -2891,6 +3039,11 @@
       "resolved": "https://registry.npmjs.org/negotiator/-/negotiator-0.6.1.tgz",
       "integrity": "sha1-KzJxhOiZIQEXeyhWP7XnECrNDKk="
     },
+    "nice-try": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/nice-try/-/nice-try-1.0.5.tgz",
+      "integrity": "sha512-1nh45deeb5olNY7eX82BkPO7SSxR5SSYJiPTrTdFUVYwAl8CKMA5N9PjTYkHiRjisVcxcQ1HXdLhx2qxxJzLNQ=="
+    },
     "nodemon": {
       "version": "1.18.9",
       "resolved": "https://registry.npmjs.org/nodemon/-/nodemon-1.18.9.tgz",
@@ -2918,6 +3071,17 @@
         "abbrev": "1"
       }
     },
+    "normalize-package-data": {
+      "version": "2.4.2",
+      "resolved": "https://registry.npmjs.org/normalize-package-data/-/normalize-package-data-2.4.2.tgz",
+      "integrity": "sha512-YcMnjqeoUckXTPKZSAsPjUPLxH85XotbpqK3w4RyCwdFQSU5FxxBys8buehkSfg0j9fKvV1hn7O0+8reEgkAiw==",
+      "requires": {
+        "hosted-git-info": "^2.1.4",
+        "is-builtin-module": "^1.0.0",
+        "semver": "2 || 3 || 4 || 5",
+        "validate-npm-package-license": "^3.0.1"
+      }
+    },
     "normalize-path": {
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/normalize-path/-/normalize-path-2.1.1.tgz",
@@ -2930,7 +3094,6 @@
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/npm-run-path/-/npm-run-path-2.0.2.tgz",
       "integrity": "sha1-NakjLfo11wZ7TLLd8jV7GHFTbF8=",
-      "dev": true,
       "requires": {
         "path-key": "^2.0.0"
       }
@@ -2942,6 +3105,11 @@
       "requires": {
         "boolbase": "~1.0.0"
       }
+    },
+    "number-is-nan": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/number-is-nan/-/number-is-nan-1.0.1.tgz",
+      "integrity": "sha1-CXtgK1NCKlIsGvuHkDGDNpQaAR0="
     },
     "oauth-sign": {
       "version": "0.9.0",
@@ -3034,11 +3202,87 @@
         "json-pointer": "^0.6.0"
       }
     },
+    "os-locale": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/os-locale/-/os-locale-3.1.0.tgz",
+      "integrity": "sha512-Z8l3R4wYWM40/52Z+S265okfFj8Kt2cC2MKY+xNi3kFs+XGI7WXu/I309QQQYbRW4ijiZ+yxs9pqEhJh0DqW3Q==",
+      "requires": {
+        "execa": "^1.0.0",
+        "lcid": "^2.0.0",
+        "mem": "^4.0.0"
+      },
+      "dependencies": {
+        "cross-spawn": {
+          "version": "6.0.5",
+          "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-6.0.5.tgz",
+          "integrity": "sha512-eTVLrBSt7fjbDygz805pMnstIs2VTBNkRm0qxZd+M7A5XDdxVRWO5MxGBXZhjY4cqLYLdtrGqRf8mBPmzwSpWQ==",
+          "requires": {
+            "nice-try": "^1.0.4",
+            "path-key": "^2.0.1",
+            "semver": "^5.5.0",
+            "shebang-command": "^1.2.0",
+            "which": "^1.2.9"
+          }
+        },
+        "execa": {
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/execa/-/execa-1.0.0.tgz",
+          "integrity": "sha512-adbxcyWV46qiHyvSp50TKt05tB4tK3HcmF7/nxfAdhnox83seTDbwnaqKO4sXRy7roHAIFqJP/Rw/AuEbX61LA==",
+          "requires": {
+            "cross-spawn": "^6.0.0",
+            "get-stream": "^4.0.0",
+            "is-stream": "^1.1.0",
+            "npm-run-path": "^2.0.0",
+            "p-finally": "^1.0.0",
+            "signal-exit": "^3.0.0",
+            "strip-eof": "^1.0.0"
+          }
+        },
+        "get-stream": {
+          "version": "4.1.0",
+          "resolved": "https://registry.npmjs.org/get-stream/-/get-stream-4.1.0.tgz",
+          "integrity": "sha512-GMat4EJ5161kIy2HevLlr4luNjBgvmj413KaQA7jt4V8B4RDsfpHk7WQ9GVqfYyyx8OS/L66Kox+rJRNklLK7w==",
+          "requires": {
+            "pump": "^3.0.0"
+          }
+        }
+      }
+    },
+    "p-defer": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/p-defer/-/p-defer-1.0.0.tgz",
+      "integrity": "sha1-n26xgvbJqozXQwBKfU+WsZaw+ww="
+    },
     "p-finally": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/p-finally/-/p-finally-1.0.0.tgz",
-      "integrity": "sha1-P7z7FbiZpEEjs0ttzBi3JDNqLK4=",
-      "dev": true
+      "integrity": "sha1-P7z7FbiZpEEjs0ttzBi3JDNqLK4="
+    },
+    "p-is-promise": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/p-is-promise/-/p-is-promise-2.0.0.tgz",
+      "integrity": "sha512-pzQPhYMCAgLAKPWD2jC3Se9fEfrD9npNos0y150EeqZll7akhEgGhTW/slB6lHku8AvYGiJ+YJ5hfHKePPgFWg=="
+    },
+    "p-limit": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-2.1.0.tgz",
+      "integrity": "sha512-NhURkNcrVB+8hNfLuysU8enY5xn2KXphsHBaC2YmRNTZRc7RWusw6apSpdEj3jo4CMb6W9nrF6tTnsJsJeyu6g==",
+      "requires": {
+        "p-try": "^2.0.0"
+      }
+    },
+    "p-locate": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/p-locate/-/p-locate-3.0.0.tgz",
+      "integrity": "sha512-x+12w/To+4GFfgJhBEpiDcLozRJGegY+Ei7/z0tSLkMmxGZNybVMSfWj9aJn8Z5Fc7dBUNJOOVgPv2H7IwulSQ==",
+      "requires": {
+        "p-limit": "^2.0.0"
+      }
+    },
+    "p-try": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/p-try/-/p-try-2.0.0.tgz",
+      "integrity": "sha512-hMp0onDKIajHfIkdRk3P4CdCmErkYAxxDtP3Wx/4nZ3aGlau2VKh3mZpcuFkH27WQkL/3WBCPOktzA9ZOAnMQQ=="
     },
     "package-json": {
       "version": "4.0.1",
@@ -3050,6 +3294,15 @@
         "registry-auth-token": "^3.0.1",
         "registry-url": "^3.0.3",
         "semver": "^5.1.0"
+      }
+    },
+    "parse-json": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/parse-json/-/parse-json-4.0.0.tgz",
+      "integrity": "sha1-vjX1Qlvh9/bHRxhPmKeIy5lHfuA=",
+      "requires": {
+        "error-ex": "^1.3.1",
+        "json-parse-better-errors": "^1.0.1"
       }
     },
     "parse5": {
@@ -3075,6 +3328,11 @@
       "resolved": "https://registry.npmjs.org/path-dirname/-/path-dirname-1.0.2.tgz",
       "integrity": "sha1-zDPSTVJeCZpTiMAzbG4yuRYGCeA="
     },
+    "path-exists": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-3.0.0.tgz",
+      "integrity": "sha1-zg6+ql94yxiSXqfYENe1mwEP1RU="
+    },
     "path-is-absolute": {
       "version": "1.0.1",
       "resolved": "http://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
@@ -3089,8 +3347,7 @@
     "path-key": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/path-key/-/path-key-2.0.1.tgz",
-      "integrity": "sha1-QRyttXTFoUDTpLGRDUDYDMn0C0A=",
-      "dev": true
+      "integrity": "sha1-QRyttXTFoUDTpLGRDUDYDMn0C0A="
     },
     "path-to-regexp": {
       "version": "0.1.7",
@@ -3110,8 +3367,7 @@
     "pify": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/pify/-/pify-3.0.0.tgz",
-      "integrity": "sha1-5aSs0sEB/fPZpNB/DbxNtJ3SgXY=",
-      "dev": true
+      "integrity": "sha1-5aSs0sEB/fPZpNB/DbxNtJ3SgXY="
     },
     "polished": {
       "version": "2.3.3",
@@ -3189,6 +3445,15 @@
       "resolved": "https://registry.npmjs.org/pstree.remy/-/pstree.remy-1.1.6.tgz",
       "integrity": "sha512-NdF35+QsqD7EgNEI5mkI/X+UwaxVEbQaz9f4IooEmMUv6ZPmlTQYGjBPJGgrlzNdjSvIy4MWMg6Q6vCgBO2K+w==",
       "dev": true
+    },
+    "pump": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/pump/-/pump-3.0.0.tgz",
+      "integrity": "sha512-LwZy+p3SFs1Pytd/jYct4wpv49HiYCqd9Rlc5ZVdk0V+8Yzv6jR5Blk3TRmPL1ft69TxP0IMZGJ+WPFU2BFhww==",
+      "requires": {
+        "end-of-stream": "^1.1.0",
+        "once": "^1.3.1"
+      }
     },
     "punycode": {
       "version": "2.1.1",
@@ -3304,6 +3569,16 @@
       "requires": {
         "classnames": "^2.2.0",
         "prop-types": "^15.5.0"
+      }
+    },
+    "read-pkg": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/read-pkg/-/read-pkg-4.0.1.tgz",
+      "integrity": "sha1-ljYlN48+HE1IyFhytabsfV0JMjc=",
+      "requires": {
+        "normalize-package-data": "^2.3.2",
+        "parse-json": "^4.0.0",
+        "pify": "^3.0.0"
       }
     },
     "readable-stream": {
@@ -3476,6 +3751,16 @@
         "uuid": "^3.3.2"
       }
     },
+    "require-directory": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/require-directory/-/require-directory-2.1.1.tgz",
+      "integrity": "sha1-jGStX9MNqxyXbiNE/+f3kqam30I="
+    },
+    "require-main-filename": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/require-main-filename/-/require-main-filename-1.0.1.tgz",
+      "integrity": "sha1-l/cXtp1IeE9fUmpsWqj/3aBVpNE="
+    },
     "require_optional": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/require_optional/-/require_optional-1.0.1.tgz",
@@ -3504,6 +3789,14 @@
       "version": "0.1.2",
       "resolved": "https://registry.npmjs.org/rootpath/-/rootpath-0.1.2.tgz",
       "integrity": "sha1-Wzeah9ypBum5HWkKWZQ5vvJn6ms="
+    },
+    "rxjs": {
+      "version": "6.4.0",
+      "resolved": "https://registry.npmjs.org/rxjs/-/rxjs-6.4.0.tgz",
+      "integrity": "sha512-Z9Yfa11F6B9Sg/BK9MnqnQ+aQYicPLtilXBp2yUtDt2JRCE0h26d33EnfO3ZxoNxG0T92OUucP3Ct7cpfkdFfw==",
+      "requires": {
+        "tslib": "^1.9.0"
+      }
     },
     "safe-buffer": {
       "version": "5.1.2",
@@ -3636,6 +3929,11 @@
         "send": "0.16.2"
       }
     },
+    "set-blocking": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/set-blocking/-/set-blocking-2.0.0.tgz",
+      "integrity": "sha1-BF+XgtARrppoA93TgrJDkrPYkPc="
+    },
     "set-value": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/set-value/-/set-value-2.0.0.tgz",
@@ -3671,7 +3969,6 @@
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/shebang-command/-/shebang-command-1.2.0.tgz",
       "integrity": "sha1-RKrGW2lbAzmJaMOfNj/uXer98eo=",
-      "dev": true,
       "requires": {
         "shebang-regex": "^1.0.0"
       }
@@ -3679,14 +3976,12 @@
     "shebang-regex": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/shebang-regex/-/shebang-regex-1.0.0.tgz",
-      "integrity": "sha1-2kL0l0DAtC2yypcoVxyxkMmO/qM=",
-      "dev": true
+      "integrity": "sha1-2kL0l0DAtC2yypcoVxyxkMmO/qM="
     },
     "signal-exit": {
       "version": "3.0.2",
       "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.2.tgz",
-      "integrity": "sha1-tf3AjxKH6hF4Yo5BXiUTK3NkbG0=",
-      "dev": true
+      "integrity": "sha1-tf3AjxKH6hF4Yo5BXiUTK3NkbG0="
     },
     "sliced": {
       "version": "1.0.1",
@@ -3834,6 +4129,39 @@
         "memory-pager": "^1.0.2"
       }
     },
+    "spawn-command": {
+      "version": "0.0.2-1",
+      "resolved": "https://registry.npmjs.org/spawn-command/-/spawn-command-0.0.2-1.tgz",
+      "integrity": "sha1-YvXpRmmBwbeW3Fkpk34RycaSG9A="
+    },
+    "spdx-correct": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/spdx-correct/-/spdx-correct-3.1.0.tgz",
+      "integrity": "sha512-lr2EZCctC2BNR7j7WzJ2FpDznxky1sjfxvvYEyzxNyb6lZXHODmEoJeFu4JupYlkfha1KZpJyoqiJ7pgA1qq8Q==",
+      "requires": {
+        "spdx-expression-parse": "^3.0.0",
+        "spdx-license-ids": "^3.0.0"
+      }
+    },
+    "spdx-exceptions": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/spdx-exceptions/-/spdx-exceptions-2.2.0.tgz",
+      "integrity": "sha512-2XQACfElKi9SlVb1CYadKDXvoajPgBVPn/gOQLrTvHdElaVhr7ZEbqJaRnJLVNeaI4cMEAgVCeBMKF6MWRDCRA=="
+    },
+    "spdx-expression-parse": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/spdx-expression-parse/-/spdx-expression-parse-3.0.0.tgz",
+      "integrity": "sha512-Yg6D3XpRD4kkOmTpdgbUiEJFKghJH03fiC1OPll5h/0sO6neh2jqRDVHOQ4o/LMea0tgCkbMgea5ip/e+MkWyg==",
+      "requires": {
+        "spdx-exceptions": "^2.1.0",
+        "spdx-license-ids": "^3.0.0"
+      }
+    },
+    "spdx-license-ids": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/spdx-license-ids/-/spdx-license-ids-3.0.3.tgz",
+      "integrity": "sha512-uBIcIl3Ih6Phe3XHK1NqboJLdGfwr1UN3k6wSD1dZpmPsIkb8AGNbZYJ1fOBk834+Gxy8rpfDxrS6XLEMZMY2g=="
+    },
     "split-string": {
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/split-string/-/split-string-3.1.0.tgz",
@@ -3896,7 +4224,6 @@
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/string-width/-/string-width-2.1.1.tgz",
       "integrity": "sha512-nOqH59deCq9SRHlxq1Aw85Jnt4w6KvLKqWVik6oA9ZklXLNIOlqg4F2yrT1MVaTjAqvVwdfeZ7w7aCvJD7ugkw==",
-      "dev": true,
       "requires": {
         "is-fullwidth-code-point": "^2.0.0",
         "strip-ansi": "^4.0.0"
@@ -3914,7 +4241,6 @@
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-4.0.0.tgz",
       "integrity": "sha1-qEeQIusaw2iocTibY1JixQXuNo8=",
-      "dev": true,
       "requires": {
         "ansi-regex": "^3.0.0"
       }
@@ -3922,8 +4248,7 @@
     "strip-eof": {
       "version": "1.0.0",
       "resolved": "http://registry.npmjs.org/strip-eof/-/strip-eof-1.0.0.tgz",
-      "integrity": "sha1-u0P/VZim6wXYm1n80SnJgzE2Br8=",
-      "dev": true
+      "integrity": "sha1-u0P/VZim6wXYm1n80SnJgzE2Br8="
     },
     "strip-json-comments": {
       "version": "2.0.1",
@@ -3935,7 +4260,6 @@
       "version": "5.4.0",
       "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.4.0.tgz",
       "integrity": "sha512-zjaXglF5nnWpsq470jSv6P9DwPvgLkuapYmfDm3JWOm0vkNTVF2tI4UrN2r6jH1qM/uc/WtxYY1hYoA2dOKj5w==",
-      "dev": true,
       "requires": {
         "has-flag": "^3.0.0"
       }
@@ -4371,6 +4695,11 @@
         }
       }
     },
+    "tree-kill": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/tree-kill/-/tree-kill-1.2.1.tgz",
+      "integrity": "sha512-4hjqbObwlh2dLyW4tcz0Ymw0ggoaVDMveUB9w8kFSQScdRLo0gxO9J7WFcUBo+W3C1TLdFIEwNOWebgZZ0RH9Q=="
+    },
     "tslib": {
       "version": "1.9.3",
       "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.9.3.tgz",
@@ -4611,6 +4940,15 @@
       "resolved": "https://registry.npmjs.org/uuid/-/uuid-3.3.2.tgz",
       "integrity": "sha512-yXJmeNaw3DnnKAOKJE51sL/ZaYfWJRl1pK9dr19YFCu0ObS231AB1/LbqTKRAQ5kw8A90rA6fr4riOUpTZvQZA=="
     },
+    "validate-npm-package-license": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/validate-npm-package-license/-/validate-npm-package-license-3.0.4.tgz",
+      "integrity": "sha512-DpKm2Ui/xN7/HQKCtpZxoRWBhZ9Z0kqtygG8XCgNQ8ZlDnxuQmWhj566j8fN4Cu3/JmbhsDo7fcAJq4s9h27Ew==",
+      "requires": {
+        "spdx-correct": "^3.0.0",
+        "spdx-expression-parse": "^3.0.0"
+      }
+    },
     "validator": {
       "version": "10.11.0",
       "resolved": "https://registry.npmjs.org/validator/-/validator-10.11.0.tgz",
@@ -4640,10 +4978,14 @@
       "version": "1.3.1",
       "resolved": "https://registry.npmjs.org/which/-/which-1.3.1.tgz",
       "integrity": "sha512-HxJdYWq1MTIQbJ3nw0cqssHoTNU267KlrDuGZ1WYlxDStUtKUhOaJmh112/TZmHxxUfuJqPXSOm7tDyas0OSIQ==",
-      "dev": true,
       "requires": {
         "isexe": "^2.0.0"
       }
+    },
+    "which-module": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/which-module/-/which-module-2.0.0.tgz",
+      "integrity": "sha1-2e8H3Od7mQK4o6j6SzHD4/fm6Ho="
     },
     "widest-line": {
       "version": "2.0.1",
@@ -4652,6 +4994,48 @@
       "dev": true,
       "requires": {
         "string-width": "^2.1.1"
+      }
+    },
+    "wrap-ansi": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-2.1.0.tgz",
+      "integrity": "sha1-2Pw9KE3QV5T+hJc8rs3Rz4JP3YU=",
+      "requires": {
+        "string-width": "^1.0.1",
+        "strip-ansi": "^3.0.1"
+      },
+      "dependencies": {
+        "ansi-regex": {
+          "version": "2.1.1",
+          "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz",
+          "integrity": "sha1-w7M6te42DYbg5ijwRorn7yfWVN8="
+        },
+        "is-fullwidth-code-point": {
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-1.0.0.tgz",
+          "integrity": "sha1-754xOG8DGn8NZDr4L95QxFfvAMs=",
+          "requires": {
+            "number-is-nan": "^1.0.0"
+          }
+        },
+        "string-width": {
+          "version": "1.0.2",
+          "resolved": "https://registry.npmjs.org/string-width/-/string-width-1.0.2.tgz",
+          "integrity": "sha1-EYvfW4zcUaKn5w0hHgfisLmxB9M=",
+          "requires": {
+            "code-point-at": "^1.0.0",
+            "is-fullwidth-code-point": "^1.0.0",
+            "strip-ansi": "^3.0.0"
+          }
+        },
+        "strip-ansi": {
+          "version": "3.0.1",
+          "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
+          "integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
+          "requires": {
+            "ansi-regex": "^2.0.0"
+          }
+        }
       }
     },
     "wrappy": {
@@ -4690,11 +5074,51 @@
       "resolved": "https://registry.npmjs.org/xmlbuilder/-/xmlbuilder-9.0.1.tgz",
       "integrity": "sha1-kc1wiXdVNj66V8Et3uq0o0GmH2U="
     },
+    "y18n": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/y18n/-/y18n-4.0.0.tgz",
+      "integrity": "sha512-r9S/ZyXu/Xu9q1tYlpsLIsa3EeLXXk0VwlxqTcFRfg9EhMW+17kbt9G0NrgCmhGb5vT2hyhJZLfDGx+7+5Uj/w=="
+    },
     "yallist": {
       "version": "2.1.2",
       "resolved": "https://registry.npmjs.org/yallist/-/yallist-2.1.2.tgz",
       "integrity": "sha1-HBH5IY8HYImkfdUS+TxmmaaoHVI=",
       "dev": true
+    },
+    "yargs": {
+      "version": "12.0.5",
+      "resolved": "https://registry.npmjs.org/yargs/-/yargs-12.0.5.tgz",
+      "integrity": "sha512-Lhz8TLaYnxq/2ObqHDql8dX8CJi97oHxrjUcYtzKbbykPtVW9WB+poxI+NM2UIzsMgNCZTIf0AQwsjK5yMAqZw==",
+      "requires": {
+        "cliui": "^4.0.0",
+        "decamelize": "^1.2.0",
+        "find-up": "^3.0.0",
+        "get-caller-file": "^1.0.1",
+        "os-locale": "^3.0.0",
+        "require-directory": "^2.1.1",
+        "require-main-filename": "^1.0.1",
+        "set-blocking": "^2.0.0",
+        "string-width": "^2.0.0",
+        "which-module": "^2.0.0",
+        "y18n": "^3.2.1 || ^4.0.0",
+        "yargs-parser": "^11.1.1"
+      }
+    },
+    "yargs-parser": {
+      "version": "11.1.1",
+      "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-11.1.1.tgz",
+      "integrity": "sha512-C6kB/WJDiaxONLJQnF8ccx9SEeoTTLek8RVbaOIsrAUS8VrBEXfmeSnCZxygc+XC2sNMBIwOOnfcxiynjHsVSQ==",
+      "requires": {
+        "camelcase": "^5.0.0",
+        "decamelize": "^1.2.0"
+      },
+      "dependencies": {
+        "camelcase": {
+          "version": "5.0.0",
+          "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-5.0.0.tgz",
+          "integrity": "sha512-faqwZqnWxbxn+F1d399ygeamQNy3lPp/H9H6rNrqYh4FSVCtcY+3cub1MxA8o9mDd55mM8Aghuu/kuyYA6VTsA=="
+        }
+      }
     },
     "z-schema": {
       "version": "3.24.2",

--- a/api/package.json
+++ b/api/package.json
@@ -5,8 +5,10 @@
   "main": "server.js",
   "scripts": {
     "dev": "nodemon server.js",
+    "frontend": "npm start --prefix ../frontend",
     "check-status": "node helpers/monitor.js",
-    "test": "nyc mocha --timeout 10000"
+    "test": "nyc mocha --timeout 10000",
+    "full": "concurrently \"npm run dev\" \"npm run frontend\""
   },
   "repository": {
     "type": "git",
@@ -24,6 +26,7 @@
     "axios": "^0.18.0",
     "body-parser": "^1.18.3",
     "cheerio": "^1.0.0-rc.2",
+    "concurrently": "^4.1.0",
     "cors": "^2.8.5",
     "cron": "^1.5.0",
     "crypto-js": "^3.1.9-1",

--- a/frontend/src/components/DownAlert.js
+++ b/frontend/src/components/DownAlert.js
@@ -1,0 +1,28 @@
+import React, { Component } from "react";
+import { Alert } from "reactstrap";
+
+class DownAlert extends Component {
+  constructor(props) {
+    super(props);
+    this.state = {
+      errorMessage:
+        "Sorry! There is an error with an our system. Please check back later."
+    };
+  }
+
+  render() {
+    return (
+      <div>
+        {this.props.offline ? (
+          <Alert className="text-center" color="danger">
+            {this.state.errorMessage}
+          </Alert>
+        ) : (
+          ""
+        )}
+      </div>
+    );
+  }
+}
+
+export default DownAlert;

--- a/frontend/src/components/Home.js
+++ b/frontend/src/components/Home.js
@@ -5,15 +5,16 @@ class Home extends Component {
   constructor(props) {
     super(props);
     this.state = {
-      confirmed: 0
+      confirmed: 0,
+      message: ""
     };
   }
 
   componentDidMount() {
     fetch("http://api.parkingnotifier.com/stats")
       .then(res => {
-        if (res.ok) {
-          return res.JSON();
+        if (res == null) {
+          return res.json();
         } else {
           throw new Error(
             "Something went wrong. Fetch returned null value, check if API is down"
@@ -23,13 +24,20 @@ class Home extends Component {
       .then(result => {
         console.log(result);
         this.setState({
-          confirmed: result.confirmed
+          confirmed: result.confirmed,
+          message:
+            "Join " +
+            this.state.confirmed
+              .toString()
+              .replace(/\B(?=(\d{3})+(?!\d))/g, ",") +
+            " Others"
         });
       })
       .catch(err => {
         console.log(err);
         this.setState({
-          confirmed: 0
+          confirmed: 0,
+          message: "Join Now"
         });
       });
   }
@@ -93,13 +101,7 @@ class Home extends Component {
             </ul>
           </div>
           <a href="/register">
-            <div className="button">
-              Join{" "}
-              {this.state.confirmed
-                .toString()
-                .replace(/\B(?=(\d{3})+(?!\d))/g, ",")}{" "}
-              others
-            </div>
+            <div className="button">{this.state.message}</div>
           </a>
         </div>
       </div>

--- a/frontend/src/components/Home.js
+++ b/frontend/src/components/Home.js
@@ -11,11 +11,25 @@ class Home extends Component {
 
   componentDidMount() {
     fetch("http://api.parkingnotifier.com/stats")
-      .then(res => res.json())
+      .then(res => {
+        if (res.ok) {
+          return res.JSON();
+        } else {
+          throw new Error(
+            "Something went wrong. Fetch returned null value, check if API is down"
+          );
+        }
+      })
       .then(result => {
         console.log(result);
         this.setState({
           confirmed: result.confirmed
+        });
+      })
+      .catch(err => {
+        console.log(err);
+        this.setState({
+          confirmed: 0
         });
       });
   }

--- a/frontend/src/components/Home.js
+++ b/frontend/src/components/Home.js
@@ -1,12 +1,14 @@
 import React, { Component } from "react";
 import AppNavbar from "./AppNavbar";
+import DownAlert from "./DownAlert";
 
 class Home extends Component {
   constructor(props) {
     super(props);
     this.state = {
       confirmed: 0,
-      message: ""
+      message: "",
+      offline: false
     };
   }
 
@@ -37,7 +39,8 @@ class Home extends Component {
         console.log(err);
         this.setState({
           confirmed: 0,
-          message: "Join Now"
+          message: "Join Now",
+          offline: true
         });
       });
   }
@@ -47,6 +50,7 @@ class Home extends Component {
       <div className="App">
         <AppNavbar />
         <div className="content navbar-offset">
+          <DownAlert offline={this.state.offline} />
           <img
             src={require("../media/clearwater_logo.png")}
             className="img-responsive"
@@ -54,6 +58,7 @@ class Home extends Component {
             alt="cwlLogo"
           />
         </div>
+
         <div className="container">
           <h1> Parking Notifier </h1>
           <h4>The Alternate Side Parking Messaging Service</h4>
@@ -100,9 +105,13 @@ class Home extends Component {
               </li>
             </ul>
           </div>
-          <a href="/register">
-            <div className="button">{this.state.message}</div>
-          </a>
+          {this.state.offline ? (
+            ""
+          ) : (
+            <a href="/register">
+              <div className="button">{this.state.message}</div>
+            </a>
+          )}
         </div>
       </div>
     );

--- a/frontend/src/components/Register.js
+++ b/frontend/src/components/Register.js
@@ -38,10 +38,24 @@ class Register extends Component {
 
   componentDidMount() {
     fetch("http://api.parkingnotifier.com/stats")
-      .then(res => res.json())
+      .then(res => {
+        if (res.ok) {
+          return res.JSON();
+        } else {
+          throw new Error(
+            "Something went wrong. Fetch returned null value, check if API is down"
+          );
+        }
+      })
       .then(result => {
         this.setState({
           confirmed: result.confirmed
+        });
+      })
+      .catch(err => {
+        console.log(err);
+        this.setState({
+          confirmed: 0
         });
       });
   }

--- a/frontend/src/components/Register.js
+++ b/frontend/src/components/Register.js
@@ -23,6 +23,7 @@ class Register extends Component {
     super(props);
     this.state = {
       confirmed: 0,
+      joinMessage: "",
       fname: "",
       lname: "",
       phone: "",
@@ -39,8 +40,8 @@ class Register extends Component {
   componentDidMount() {
     fetch("http://api.parkingnotifier.com/stats")
       .then(res => {
-        if (res.ok) {
-          return res.JSON();
+        if (res == null) {
+          return res.json();
         } else {
           throw new Error(
             "Something went wrong. Fetch returned null value, check if API is down"
@@ -49,13 +50,20 @@ class Register extends Component {
       })
       .then(result => {
         this.setState({
-          confirmed: result.confirmed
+          confirmed: result.confirmed,
+          joinMessage:
+            "Join " +
+            this.state.confirmed
+              .toString()
+              .replace(/\B(?=(\d{3})+(?!\d))/g, ",") +
+            " others receiving text alerts. "
         });
       })
       .catch(err => {
         console.log(err);
         this.setState({
-          confirmed: 0
+          confirmed: 0,
+          joinMessage: "Join everyone else receiving text alerts."
         });
       });
   }
@@ -150,13 +158,7 @@ class Register extends Component {
                 will end (3 days after the start of the rules).
               </h6>
               <div className="statCard">
-                <h4>
-                  Join{" "}
-                  {this.state.confirmed
-                    .toString()
-                    .replace(/\B(?=(\d{3})+(?!\d))/g, ",")}{" "}
-                  others receiving text alerts.
-                </h4>
+                <h4>{this.state.joinMessage}</h4>
               </div>
             </Container>
             {this.state.submitSuccess ? (

--- a/frontend/src/components/Register.js
+++ b/frontend/src/components/Register.js
@@ -12,11 +12,9 @@ import {
   FormFeedback,
   Alert
 } from "reactstrap";
+import DownAlert from "./DownAlert";
 
 var PhoneNumber = require("awesome-phonenumber");
-var imgStyle = {
-  display: "inline"
-};
 
 class Register extends Component {
   constructor(props) {
@@ -24,6 +22,8 @@ class Register extends Component {
     this.state = {
       confirmed: 0,
       joinMessage: "",
+      errorMessage: "",
+      offline: false,
       fname: "",
       lname: "",
       phone: "",
@@ -63,7 +63,8 @@ class Register extends Component {
         console.log(err);
         this.setState({
           confirmed: 0,
-          joinMessage: "Join everyone else receiving text alerts."
+          joinMessage: "Join everyone else receiving text alerts.",
+          offline: true
         });
       });
   }
@@ -147,6 +148,7 @@ class Register extends Component {
       <div>
         <AppNavbar />
         <div className="container navbar-offset" />
+        <DownAlert offline={this.state.offline} />
         <div className="row">
           <div className="col align-self-center">
             <Container>
@@ -161,98 +163,101 @@ class Register extends Component {
                 <h4>{this.state.joinMessage}</h4>
               </div>
             </Container>
-            {this.state.submitSuccess ? (
-              <Container>
-                <Alert color="success">
-                  <h5 className="alert-heading">
-                    We've sent a confirmation email to {this.state.email}. Click
-                    the link in the email to complete the registration process.
-                  </h5>
-                </Alert>
-              </Container>
+            {this.state.offline ? (
+              ""
             ) : (
-              <Form onSubmit={this.handleSubmit}>
-                {this.state.formValid ? (
-                  ""
+              <div>
+                {this.state.submitSuccess ? (
+                  <Container>
+                    <Alert color="success">
+                      <h5 className="alert-heading">
+                        We've sent a confirmation email to {this.state.email}.
+                        Click the link in the email to complete the registration
+                        process.
+                      </h5>
+                    </Alert>
+                  </Container>
                 ) : (
-                  <Alert className="text-center" color="danger">
-                    {this.state.message}
-                  </Alert>
-                )}
+                  <Form onSubmit={this.handleSubmit}>
+                    {this.state.formValid ? (
+                      ""
+                    ) : (
+                      <Alert className="text-center" color="danger">
+                        {this.state.message}
+                      </Alert>
+                    )}
 
-                <Label htmlFor="frmNameA">Name</Label>
-                <Row>
-                  <Col md={6}>
+                    <Label htmlFor="frmNameA">Name</Label>
+                    <Row>
+                      <Col md={6}>
+                        <FormGroup>
+                          <Input
+                            type="text"
+                            name="fname"
+                            id="frmNameA"
+                            placeholder="First"
+                            required
+                            autoComplete="given-name"
+                            value={this.state.fname}
+                            onChange={event => this.handleInput(event)}
+                          />
+                        </FormGroup>
+                      </Col>
+                      <Col md={6}>
+                        <FormGroup>
+                          <Input
+                            id="lName"
+                            name="lname"
+                            type="text"
+                            placeholder="Last"
+                            required
+                            autoComplete="family-name"
+                            value={this.state.lname}
+                            onChange={event => this.handleInput(event)}
+                          />
+                        </FormGroup>
+                      </Col>
+                    </Row>
                     <FormGroup>
+                      <Label>Phone Number</Label>
                       <Input
-                        type="text"
-                        name="fname"
-                        id="frmNameA"
-                        placeholder="First"
                         required
-                        autoComplete="given-name"
-                        value={this.state.fname}
+                        type="tel"
+                        className="form-control"
+                        id="phoneNumber"
+                        name="phone"
+                        value={this.state.phone}
                         onChange={event => this.handleInput(event)}
+                        invalid={!!!this.state.phoneValid}
                       />
+                      <FormFeedback>Must be a valid phone number</FormFeedback>
                     </FormGroup>
-                  </Col>
-                  <Col md={6}>
                     <FormGroup>
+                      <Label>UWEC Email</Label>
                       <Input
-                        id="lName"
-                        name="lname"
-                        type="text"
-                        placeholder="Last"
+                        name="email"
+                        type="email"
                         required
-                        autoComplete="family-name"
-                        value={this.state.lname}
+                        placeholder="username@uwec.edu"
+                        autoComplete="email"
+                        value={this.state.email}
                         onChange={event => this.handleInput(event)}
+                        invalid={!!!this.state.emailValid}
                       />
+                      <FormFeedback>Must be a valid UWEC email.</FormFeedback>
                     </FormGroup>
-                  </Col>
-                </Row>
-                <FormGroup>
-                  <Label>Phone Number</Label>
-                  <Input
-                    required
-                    type="tel"
-                    className="form-control"
-                    id="phoneNumber"
-                    name="phone"
-                    value={this.state.phone}
-                    onChange={event => this.handleInput(event)}
-                    invalid={!!!this.state.phoneValid}
-                  />
-                  <FormFeedback>Must be a valid phone number</FormFeedback>
-                </FormGroup>
-                <FormGroup>
-                  <Label>UWEC Email</Label>
-                  <Input
-                    name="email"
-                    type="email"
-                    required
-                    placeholder="username@uwec.edu"
-                    autoComplete="email"
-                    value={this.state.email}
-                    onChange={event => this.handleInput(event)}
-                    invalid={!!!this.state.emailValid}
-                  />
-                  <FormFeedback>Must be a valid UWEC email.</FormFeedback>
-                </FormGroup>
-                <Button outline block color="primary" type="submit">
-                  Register
-                </Button>
-              </Form>
+                    <Button outline block color="primary" type="submit">
+                      Register
+                    </Button>
+                  </Form>
+                )}
+              </div>
             )}
           </div>
           {this.state.submitSuccess ? (
             <div />
           ) : (
-            <div
-              id="exampleContainer"
-              className="col align-self-center"
-              style={imgStyle}
-            >
+            <div id="exampleContainer" className="col align-self-center">
               <img
                 src={require("../media/demo_text_2.png")}
                 className="text-example-img"

--- a/frontend/src/components/unsubscribe.js
+++ b/frontend/src/components/unsubscribe.js
@@ -10,17 +10,47 @@ import {
   Container
 } from "reactstrap";
 import AppNavbar from "./AppNavbar";
+import DownAlert from "./DownAlert";
 
 class Unsubscribe extends Component {
   constructor(props) {
     super(props);
     this.state = {
       email: "",
+      confirmed: 0,
       formValid: true,
       emailValid: true,
-      message: ""
+      message: "",
+      offline: false
     };
     this.handleSubmit = this.handleSubmit.bind(this);
+  }
+
+  componentDidMount() {
+    fetch("http://api.parkingnotifier.com/stats")
+      .then(res => {
+        if (res == null) {
+          return res.json();
+        } else {
+          throw new Error(
+            "Something went wrong. Fetch returned null value, check if API is down"
+          );
+        }
+      })
+      .then(result => {
+        console.log(result);
+        this.setState({
+          confirmed: result.confirmed,
+          offline: false
+        });
+      })
+      .catch(err => {
+        console.log(err);
+        this.setState({
+          confirmed: 0,
+          offline: true
+        });
+      });
   }
 
   handleInput = e => {
@@ -74,48 +104,57 @@ class Unsubscribe extends Component {
 
   render() {
     return (
-      <div className="navbar-offset">
+      <div className="App">
         <AppNavbar />
-        <div className="container content">
-          <h2>Don't want to receive updates anymore?</h2>
-          <h4>No problem.</h4>
-          <h6>Just use the info that you signed up with.</h6>
-        </div>
-        {this.state.success ? (
-          <Container>
-            <Alert color="primary">
-              It's sad to see you go. You're unsubscribed now.
-            </Alert>
-          </Container>
-        ) : (
-          <Form onSubmit={this.handleSubmit}>
-            {this.state.formValid ? (
-              ""
-            ) : (
-              <Alert className="text-center" color="danger">
-                {this.state.message}
-              </Alert>
-            )}
+        <div className="navbar-offset">
+          <DownAlert offline={this.state.offline} />
+          <div className="container content">
+            <h2>Don't want to receive updates anymore?</h2>
+            <h4>No problem.</h4>
+            <h6>Just use the info that you signed up with.</h6>
+          </div>
+          {this.state.offline ? (
+            ""
+          ) : (
+            <div>
+              {this.state.success ? (
+                <Container>
+                  <Alert color="primary">
+                    It's sad to see you go. You're unsubscribed now.
+                  </Alert>
+                </Container>
+              ) : (
+                <Form onSubmit={this.handleSubmit}>
+                  {this.state.formValid ? (
+                    ""
+                  ) : (
+                    <Alert className="text-center" color="danger">
+                      {this.state.message}
+                    </Alert>
+                  )}
 
-            <FormGroup>
-              <Label>UWEC Email</Label>
-              <Input
-                name="email"
-                type="email"
-                placeholder="username@uwec.edu"
-                required
-                autoComplete="email"
-                value={this.state.email}
-                onChange={event => this.handleInput(event)}
-                invalid={!!!this.state.emailValid}
-              />
-              <FormFeedback>Must be a valid UWEC email.</FormFeedback>
-            </FormGroup>
-            <Button outline block color="primary" type="submit">
-              Unsubscribe
-            </Button>
-          </Form>
-        )}
+                  <FormGroup>
+                    <Label>UWEC Email</Label>
+                    <Input
+                      name="email"
+                      type="email"
+                      placeholder="username@uwec.edu"
+                      required
+                      autoComplete="email"
+                      value={this.state.email}
+                      onChange={event => this.handleInput(event)}
+                      invalid={!!!this.state.emailValid}
+                    />
+                    <FormFeedback>Must be a valid UWEC email.</FormFeedback>
+                  </FormGroup>
+                  <Button outline block color="primary" type="submit">
+                    Unsubscribe
+                  </Button>
+                </Form>
+              )}
+            </div>
+          )}
+        </div>
       </div>
     );
   }


### PR DESCRIPTION
Added a check and catch on frontend fetches for user count so that if the API is down the frontend still persists. When the API is down, all pages will have an alert banner indicating that our systems are down and that the user should check back later. Also, when under this alert, the home page's "Join" button, the register form, and the unsubscribe form are no longer rendered.

Side feature: Added concurrently script to the api package.json so that you can run "npm run full" within the api and it will bring up both the front end and backend.

Resolves #135