### PR TITLE
Fix Down API Handler

### DIFF
--- a/frontend/src/components/Home.js
+++ b/frontend/src/components/Home.js
@@ -15,7 +15,7 @@ class Home extends Component {
   componentDidMount() {
     fetch("http://api.parkingnotifier.com/stats")
       .then(res => {
-        if (res == null) {
+        if (res !== null) {
           return res.json();
         } else {
           throw new Error(

--- a/frontend/src/components/Register.js
+++ b/frontend/src/components/Register.js
@@ -40,7 +40,7 @@ class Register extends Component {
   componentDidMount() {
     fetch("http://api.parkingnotifier.com/stats")
       .then(res => {
-        if (res == null) {
+        if (res !== null) {
           return res.json();
         } else {
           throw new Error(

--- a/frontend/src/components/unsubscribe.js
+++ b/frontend/src/components/unsubscribe.js
@@ -29,7 +29,7 @@ class Unsubscribe extends Component {
   componentDidMount() {
     fetch("http://api.parkingnotifier.com/stats")
       .then(res => {
-        if (res == null) {
+        if (res !== null) {
           return res.json();
         } else {
           throw new Error(


### PR DESCRIPTION
@taylor-misch I should've caught this but the handler's logic was backwards. It was `if (res == null)` but it should've been `if (res !== null)`.

```jsx
if (res !== null) {
  return res.json();
} else {
  throw new Error(
    "Something went wrong. Fetch returned null value, check if API is down"
  );
}
```

This should fix all of the issues regarding the down API handler. The API has been up and working for the past few days. The problem was the reversed logic.