### PR TITLE
Fixed scrape when database is empty

### DIFF
--- a/api/helpers/monitor.js
+++ b/api/helpers/monitor.js
@@ -52,8 +52,14 @@ module.exports = app => {
             };
             new ParkingStatus(newParkingStatus)
               .save()
-              .then(console.log("Dummy False ParkingStatus save successful"))
+              .then(
+                console.log(
+                  JSON.stringify(newParkingStatus) +
+                    "\nDummy False ParkingStatus save successful"
+                )
+              )
               .catch(err => console.log(err));
+            oldStatus = newParkingStatus;
           }
 
           //checking if html contains alternate parking listing by scanning "latest news" items from EC website


### PR DESCRIPTION
Our logic was correct, just changed it so that when the dummy record was put in all the other functions would use the dummy record instead of the empty record. 

Resolves #150