### PR TITLE
Fix for inaccurate logging due to timezone differences

### DIFF
--- a/api/controllers/parkingStatus.js
+++ b/api/controllers/parkingStatus.js
@@ -6,11 +6,6 @@ mongoose.model("ParkingStatus");
 exports.getStatus = (req, res) => {
   ParkingStatus.find((err, parkingStatus) => {
     if (err) return console.error(err);
-    res.status(200).send({
-      inEffect: parkingStatus.inEffect,
-      start: parkingStatus.start,
-      end: parkingStatus.end,
-      timestamp: parkingStatus.timestamp
-    });
+    res.status(200).send({ parkingStatus });
   });
 };

--- a/api/helpers/monitor.js
+++ b/api/helpers/monitor.js
@@ -78,7 +78,12 @@ module.exports = app => {
 
             new ParkingStatus(newParkingStatus)
               .save()
-              .then(console.log("ParkingStatus save successful"))
+              .then(
+                console.log(
+                  JSON.stringify(newParkingStatus) +
+                    "ParkingStatus save successful"
+                )
+              )
               .catch(err => console.log(err));
 
             if (isNew) {
@@ -98,7 +103,12 @@ module.exports = app => {
             };
             new ParkingStatus(newParkingStatus)
               .save()
-              .then(console.log("ParkingStatus save successful"))
+              .then(
+                console.log(
+                  JSON.stringify(newParkingStatus) +
+                    "ParkingStatus save successful"
+                )
+              )
               .catch(err => console.log(err));
           }
         });

--- a/api/routes/parkingStatus.js
+++ b/api/routes/parkingStatus.js
@@ -1,8 +1,5 @@
 module.exports = app => {
   var parkingStatusController = require("../controllers/parkingStatus");
 
-  app
-    .route("/status")
-    .get(parkingStatusController.getStatus)
-    .delete(parkingStatusController.deleteStatus);
+  app.route("/status").get(parkingStatusController.getStatus);
 };

--- a/api/server.js
+++ b/api/server.js
@@ -87,8 +87,8 @@ app.use((error, req, res, next) => {
 });
 
 new CronJob(
-  "0 18 * * * ", //runs at 6pm everyday
-  //"*/15 * * * * *", //runs every 10 seconds (testing purposes only)
+  "16 10 * * * ", //runs at 5:30pm everyday
+  //"*/15 * * * * *", //runs every 15 seconds (testing purposes only)
   () => {
     console.log(
       "[" +

--- a/api/server.js
+++ b/api/server.js
@@ -87,7 +87,7 @@ app.use((error, req, res, next) => {
 });
 
 new CronJob(
-  "16 10 * * * ", //runs at 5:30pm everyday
+  "30 17 * * * ", //runs at 5:30pm everyday
   //"*/15 * * * * *", //runs every 15 seconds (testing purposes only)
   () => {
     console.log(


### PR DESCRIPTION
Change on parkingStatus Controller: 
- during testing, the logging of individual pieces of the parking status was not showing up on my machine. Needs further testing before we can go that route, so I switched it back.

Change on `monitor.js`:
- added a stringified version of the newly saved parking status for better logging transparency

Change on parkingStatus Route:
- removed delete route for the non-existing functionality

Change on `server.js`: (most important)
- changed the web scrape so that it runs at 5:30 pm instead of 6:00 pm. This will fix the issue of the timezone change problem. When not in daylight savings, there is a  6-hour difference between Central Standard time and the UTC time that our container is running on (5-hour difference after it starts). This difference causes us to log all of our scrapes not at 6 pm but at 12 am (the next day). 
- By moving the scrape to 5:30 pm, we will keep the scrape working on the same day as it actually occurs, allowing our logging to be more accurate (the timestamp will still show as occurring at 11:30pm at night, but staying on the same day is the most important factor). If the day is off, then our logs will reflect alternate side parking start and end dates that are 1 day off (which will prevent us from automating this like we hope to). 
- After the last few snow events, I've noticed the "latest news" posting for alternate side parking go away immediately following its conclusion at 5 pm, so there is no worry for overlap. 
- Eventually, the best solution would be to change the timezone of the containers we are using to run the parking notifier. 

resolves #169 