### PR TITLE
Fix Docs

### DIFF
--- a/api/package-lock.json
+++ b/api/package-lock.json
@@ -172,7 +172,7 @@
     },
     "array-flatten": {
       "version": "1.1.1",
-      "resolved": "http://registry.npmjs.org/array-flatten/-/array-flatten-1.1.1.tgz",
+      "resolved": "https://registry.npmjs.org/array-flatten/-/array-flatten-1.1.1.tgz",
       "integrity": "sha1-ml9pkFGx5wczKPKgCJaLZOopVdI="
     },
     "array-unique": {
@@ -259,7 +259,7 @@
     },
     "axios": {
       "version": "0.18.0",
-      "resolved": "http://registry.npmjs.org/axios/-/axios-0.18.0.tgz",
+      "resolved": "https://registry.npmjs.org/axios/-/axios-0.18.0.tgz",
       "integrity": "sha1-MtU+SFHv3AoRmTts0AB4nXDAUQI=",
       "requires": {
         "follow-redirects": "^1.3.0",
@@ -466,7 +466,7 @@
     },
     "buffer": {
       "version": "4.9.1",
-      "resolved": "http://registry.npmjs.org/buffer/-/buffer-4.9.1.tgz",
+      "resolved": "https://registry.npmjs.org/buffer/-/buffer-4.9.1.tgz",
       "integrity": "sha1-bRu2AbB6TvztlwlBMgkwJ8lbwpg=",
       "requires": {
         "base64-js": "^1.0.2",
@@ -823,7 +823,7 @@
     },
     "css-select": {
       "version": "1.2.0",
-      "resolved": "http://registry.npmjs.org/css-select/-/css-select-1.2.0.tgz",
+      "resolved": "https://registry.npmjs.org/css-select/-/css-select-1.2.0.tgz",
       "integrity": "sha1-KzoRBTnFNV8c2NMUYj6HCxIeyFg=",
       "requires": {
         "boolbase": "~1.0.0",
@@ -939,7 +939,7 @@
     },
     "deprecate": {
       "version": "1.0.0",
-      "resolved": "http://registry.npmjs.org/deprecate/-/deprecate-1.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/deprecate/-/deprecate-1.0.0.tgz",
       "integrity": "sha1-ZhSQ7SQokWpsiIPYg05WRvTkpKg="
     },
     "destroy": {
@@ -1118,7 +1118,7 @@
     },
     "events": {
       "version": "1.1.1",
-      "resolved": "http://registry.npmjs.org/events/-/events-1.1.1.tgz",
+      "resolved": "https://registry.npmjs.org/events/-/events-1.1.1.tgz",
       "integrity": "sha1-nr23Y1rQmccNzEwqH1AEKI6L2SQ="
     },
     "execa": {
@@ -2810,7 +2810,7 @@
     },
     "media-typer": {
       "version": "0.3.0",
-      "resolved": "http://registry.npmjs.org/media-typer/-/media-typer-0.3.0.tgz",
+      "resolved": "https://registry.npmjs.org/media-typer/-/media-typer-0.3.0.tgz",
       "integrity": "sha1-hxDXrwqmJvj/+hzgAWhUUmMlV0g="
     },
     "mem": {
@@ -4335,7 +4335,7 @@
       "dependencies": {
         "readable-stream": {
           "version": "2.3.6",
-          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.6.tgz",
+          "resolved": "http://registry.npmjs.org/readable-stream/-/readable-stream-2.3.6.tgz",
           "integrity": "sha512-tQtKA9WIAhBF3+VLAseyMqZeBjW0AHJoxOtYqSUZNJxauErmLbVm2FW1y+J/YA9dUrAC39ITejlZWhVIwawkKw==",
           "requires": {
             "core-util-is": "~1.0.0",
@@ -4349,7 +4349,7 @@
         },
         "string_decoder": {
           "version": "1.1.1",
-          "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
+          "resolved": "http://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
           "integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
           "requires": {
             "safe-buffer": "~5.1.0"
@@ -4556,7 +4556,7 @@
     },
     "safe-regex": {
       "version": "1.1.0",
-      "resolved": "http://registry.npmjs.org/safe-regex/-/safe-regex-1.1.0.tgz",
+      "resolved": "https://registry.npmjs.org/safe-regex/-/safe-regex-1.1.0.tgz",
       "integrity": "sha1-QKNmnzsHfR6UPURinhV91IAjvy4=",
       "requires": {
         "ret": "~0.1.10"
@@ -5046,7 +5046,7 @@
     },
     "strip-eof": {
       "version": "1.0.0",
-      "resolved": "http://registry.npmjs.org/strip-eof/-/strip-eof-1.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/strip-eof/-/strip-eof-1.0.0.tgz",
       "integrity": "sha1-u0P/VZim6wXYm1n80SnJgzE2Br8="
     },
     "strip-json-comments": {

--- a/api/redoc.html
+++ b/api/redoc.html
@@ -3,10 +3,13 @@
   <head>
     <title>Parking Notifier API | Docs</title>
     <!-- needed for adaptive design -->
-    <meta charset="utf-8"/>
-    <meta name="viewport" content="width=device-width, initial-scale=1">
-    <link href="https://fonts.googleapis.com/css?family=Montserrat:300,400,700|Roboto:300,400,700" rel="stylesheet">
- 
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <link
+      href="https://fonts.googleapis.com/css?family=Montserrat:300,400,700|Roboto:300,400,700"
+      rel="stylesheet"
+    />
+
     <!--
     ReDoc doesn't change outer page styles
     -->
@@ -15,10 +18,10 @@
         margin: 0;
         padding: 0;
       }
-    </style> 
+    </style>
   </head>
   <body>
-    <redoc spec-url='http://api.parkingnotifier.com/api-docs.json'></redoc>
-    <script src="https://cdn.jsdelivr.net/npm/redoc@next/bundles/redoc.standalone.js"> </script> 
+    <redoc spec-url="https://api.parkingnotifier.com/api-docs.json"></redoc>
+    <script src="https://cdn.jsdelivr.net/npm/redoc@next/bundles/redoc.standalone.js"></script>
   </body>
 </html>

--- a/api/routes/notify.js
+++ b/api/routes/notify.js
@@ -1,5 +1,5 @@
 module.exports = app => {
-  var notifyController = require("../../controllers/notify");
+  var notifyController = require("../controllers/notify");
   var passport = require("passport");
 
   app

--- a/api/routes/superusers.js
+++ b/api/routes/superusers.js
@@ -2,14 +2,14 @@ const express = require("express");
 const router = express.Router();
 const bcrypt = require("bcryptjs");
 const jwt = require("jsonwebtoken");
-const keys = require("../../config/keys");
+const keys = require("../config/keys");
 
 // Load input validation
-const validateRegisterInput = require("../../validation/register");
-const validateLoginInput = require("../../validation/login");
+const validateRegisterInput = require("../validation/register");
+const validateLoginInput = require("../validation/login");
 
 // Load Superuser model
-const Superuser = require("../../models/Superuser");
+const Superuser = require("../models/Superuser");
 
 const checkKey = (req, res, next) => {
   if (

--- a/api/server.js
+++ b/api/server.js
@@ -12,9 +12,9 @@ var passport = require("passport");
 
 var userRoutes = require("./routes/users");
 var statRoutes = require("./routes/stats");
-var superuserRoutes = require("./routes/dashboard/superusers");
+var superuserRoutes = require("./routes/superusers");
 var parkingStatusRoutes = require("./routes/parkingStatus");
-var notifyRoutes = require("./routes/dashboard/notify");
+var notifyRoutes = require("./routes/notify");
 var monitorHelper = require("./helpers/monitor");
 
 // import environment variables from .env file
@@ -68,7 +68,9 @@ notifyRoutes(app);
 userRoutes(app);
 statRoutes(app);
 parkingStatusRoutes(app);
-//var swaggerSpec = swaggerJSDoc(require("./swaggerConfig").options);
+
+// load in the swagger config to generate the docs
+var swaggerSpec = swaggerJSDoc(require("./swaggerConfig").options);
 
 app.get("/api-docs.json", (req, res) => {
   res.setHeader("Content-Type", "application/json");
@@ -84,8 +86,7 @@ app.use((req, res) => {
   res.status(404);
   res.json({
     status: "failed",
-    message: "This resource does not exist",
-    apiDocumentation: "https://github.com/UWEC-ITC/parkingNotifier-API"
+    message: "This resource does not exist"
   });
 });
 
@@ -94,8 +95,7 @@ app.use((error, req, res, next) => {
   console.log(error);
   res.json({
     status: "failed",
-    message: "Server error",
-    apiDocumentation: "https://github.com/UWEC-ITC/parkingNotifier-API"
+    message: "Server error"
   });
 });
 

--- a/api/swaggerConfig.js
+++ b/api/swaggerConfig.js
@@ -1,10 +1,10 @@
 exports.options = {
-    swaggerDefinition: {
-        openapi: "3.0.0",
-        info: {
-            title: "Parking Notifier API",
-            version: "1.0.0",
-            description: `
+  swaggerDefinition: {
+    openapi: "3.0.0",
+    info: {
+      title: "Parking Notifier API",
+      version: "1.0.0",
+      description: `
 This specification documentation is for the Parking Notifier API. This API is the core of the notification service provided by Clearwater Labs.
             
 ## Getting Started
@@ -14,14 +14,15 @@ version of MongoDB, Parking Notifier API, and Parking Notifier UI.
 
 These are the only two dependencies. Use \`docker-compose\` to spin up the instance of everything. This will include a mongodb instance, API instance, and a UI instance. The API will be on port 80 (127.0.0.1:80)
             `
-        },
-        host: "127.0.0.1:80",
-        tags: [
-            {
-                name: "Stats",
-                description: "Stats are used to get the user counts and the percentages of users that have confirmed their email. "
-            }
-        ]
     },
-    apis: ['./routes/*']
-}
+    host: "127.0.0.1:80",
+    tags: [
+      {
+        name: "Stats",
+        description:
+          "Stats are used to get the user counts and the percentages of users that have confirmed their email. "
+      }
+    ]
+  },
+  apis: ["./routes/*.yaml"]
+};


### PR DESCRIPTION
There were two problems:
1. The main problem was that the `redoc.html` file was not configured to use `https` and it doesn't handle the redirect well... so that's fixed now.

2. Discovered when the first was fixed, it turns out that the `/dashboard` directory was causing an issue when the Swagger OpenAPI definition generator was reaching in to get the route definitions. This should be fixed now. I just moved the two routes out of `/dashboard` directory. It was trying to read the directory as a file and was crashing.

Also, I removed the documentation key on the return object on some of the routes. It was a legacy feature and doesn't need to be there anymore.

Resolves #164 